### PR TITLE
[qtdeclarative] Don't assume DST is +1 hour

### DIFF
--- a/src/qml/jsruntime/qv4dateobject.cpp
+++ b/src/qml/jsruntime/qv4dateobject.cpp
@@ -298,7 +298,11 @@ static inline double DaylightSavingTA(double t)
     else
 #endif
         return 0;
-    return (tmtm.tm_isdst > 0) ? msPerHour : 0;
+    // Don't assume DST is +1 shift. Compute it instead.
+    if (!tmtm.tm_isdst)
+        return 0.;
+    tmtm.tm_isdst = 0;
+    return double(mktime(&tmtm) - tt) * msPerSecond;
 }
 
 static inline double LocalTime(double t)


### PR DESCRIPTION
There is a fix for this upstream from commit 2b8b7a16, see QT
bug 56787. This quick patch can be discarded from Qt5.9.

@pvuorela, this fix is simpler in my opinion than trying to backport the upstream patch. At least, it makes the Ireland time zone issue disappears on my device without breaking other DST time zones like America/Santiago.