### PR TITLE
[qtdeclarative] Commit preedit before toggling readOnly state. JB#59803

### DIFF
--- a/src/quick/items/qquicktextinput.cpp
+++ b/src/quick/items/qquicktextinput.cpp
@@ -669,6 +669,7 @@ void QQuickTextInput::setReadOnly(bool ro)
         return;
 
 #ifndef QT_NO_IM
+    d->commitPreedit();
     setFlag(QQuickItem::ItemAcceptsInputMethod, !ro);
 #endif
     d->m_readOnly = ro;


### PR DESCRIPTION
If the TextInput is turned readOnly withoug committing then the preedit text can linger and can't then be cleared, for example making it impossible to clear the visible text.

This change ensures the preedit text is committed when the readOnly state is changed.