### PR TITLE
Fix LocalStorage segfault with gcc 13. JB#63623

### DIFF
--- a/src/imports/localstorage/localstorage.pro
+++ b/src/imports/localstorage/localstorage.pro
@@ -10,3 +10,8 @@ SOURCES += plugin.cpp
 load(qml_plugin)
 
 OTHER_FILES += localstorage.json
+
+QMAKE_CFLAGS_RELEASE+=-fno-strict-aliasing
+QMAKE_CFLAGS_DEBUG+=-fno-strict-aliasing
+QMAKE_CXXFLAGS_RELEASE+=-fno-strict-aliasing
+QMAKE_CXXFLAGS_DEBUG+=-fno-strict-aliasing


### PR DESCRIPTION
Disable one `-O2` optimisation for LocalStorage subproject to prevent segfault in e.g. CSD.